### PR TITLE
Merge sections in readme and add promisifcation comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,19 +11,30 @@ Installation
 Usage
 =====
 
-Require and Instantiate OKCupidjs
-```
+All methods are asynchronous, and will return a standard `(err, res, body)` params to your callback. The body will already be json parsed into a json object for easy handling. The following demonstrates how to require and instantiate OKCupidjs.
+
+```javascript
 var OKCupid = require('okcupidjs')
 
 var okc = new OKCupid()
+
+okc.login("username", "password", function(err, res, body) {
+  console.log("done!");
+});
 ```
 
-Library Method Conventions
-==========================
-NOTE:
-All methods are Asynchronous, and will return a standard `(err, res, body)` params to your callback.
-Body will already be json parsed into a json object for easy handling.
+The library may be converted to a promise-style API by using a promise library like [bluebird.js](http://bluebirdjs.com/docs/features.html#promisification-on-steroids). This is an example using bluebird:
 
+```javascript
+var OKCupid = require('okcupidjs');
+var Promise = require('bluebird');
+
+var okc = Promise.promisifyAll(new OKCupid());
+
+okc.loginAsync("username", "password").then(function(done) {
+  console.log("done!");
+});
+```
 
 Methods
 =======


### PR DESCRIPTION
- Merge "Usage" and "Library Method Conventions" sections into one section because the extra section was unecessary
- Comments about promisifying the API go after basic usage with an example using bluebird.js